### PR TITLE
Set up Cursor Cloud dev environment (static site)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository is a **zero-dependency static website** (a personal portfolio, served in production via GitHub Pages using the domains in `CNAME`). There is no package manager, build step, backend, database, tests, or lint config.
+
+- Source of truth: `index.html` (single self-contained page with inline CSS/JS), `calendar.html` (Google Calendar iframe), and static assets under `resource/`.
+- No dependencies to install and nothing to build; there is no update/setup script beyond confirming `python3` is present.
+- Run locally by serving the repo root with any static file server, e.g. `python3 -m http.server 8000`, then open `http://localhost:8000/index.html`. In production, GitHub Pages serves the files directly on push to the default branch.
+- Interactive features to spot-check: the theme toggle (`[theme]` in the top nav / `#theme-btn`, dark↔light) and the command palette overlay (opens via the `[/]` nav item or the `/` key). Note that `Ctrl+K`/`Cmd+K` triggers the browser's own search, not the site palette.
+- Non-obvious caveats: `calendar.html` embeds a Google Calendar and will show a Google sign-in prompt rather than a calendar (expected). The page also pings an external hit counter (`api.counterapi.dev`) and loads Google Fonts; both are optional and the page renders fine offline via system-font fallbacks.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the Cursor Cloud development environment for this repository, which is a zero-dependency static portfolio website (served via GitHub Pages in production).

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting how to serve/run the site and its non-obvious caveats.
- No dependencies to install or build; the update script only verifies `python3` is available for the local static server.

## How to run locally
```
python3 -m http.server 8000
# open http://localhost:8000/index.html
```

## Testing / Walkthrough
Served the site with `python3 -m http.server 8000` and verified in Chrome:
- `index.html` loads (portfolio page).
- Theme toggle switches dark ↔ light.
- Command palette overlay opens via the `/` key.
- All assets (`calendar.html`, `resource/zhihao.JPG`, `resource/zhihao-wang-resume.pdf`) return HTTP 200.

[portfolio_site_demo.mp4](https://cursor.com/agents/bc-5b76d2c7-acbf-49ed-a8ff-ffede7eed7a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_site_demo.mp4)

[Dark theme](https://cursor.com/agents/bc-5b76d2c7-acbf-49ed-a8ff-ffede7eed7a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsite_dark_theme.webp)
[Light theme](https://cursor.com/agents/bc-5b76d2c7-acbf-49ed-a8ff-ffede7eed7a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsite_light_theme.webp)
[Command palette](https://cursor.com/agents/bc-5b76d2c7-acbf-49ed-a8ff-ffede7eed7a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsite_command_palette.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b76d2c7-acbf-49ed-a8ff-ffede7eed7a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b76d2c7-acbf-49ed-a8ff-ffede7eed7a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

